### PR TITLE
Refresh README: license, status, and content-persistence notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,17 @@
 # RFCs
-This is the repo for holding Request for Comments. Links and statuses for all RFCs are [here](https://github.com/nih-cfde/rfcs/blob/master/adoptionstatus.md)
 
-To update your DCCs opinion of a specific RFC please place a pull request with the change, or request the change in an issue and tag @Acharbonneau and @ecjoye
+This is the repo for holding Common Fund Data Ecosystem (CFDE) Requests for Comments. Links and statuses for all RFCs are [here](https://github.com/nih-cfde/rfcs/blob/master/adoptionstatus.md).
+
+To update your DCC's opinion of a specific RFC please place a pull request with the change, or request the change in an issue and tag @Acharbonneau and @ecjoye.
+
+## Status / maintenance
+
+This repository tracks the historical CFDE RFC process. It is the canonical index of the RFCs that were circulated for community comment, along with their per-RFC adoption status. See [adoptionstatus.md](adoptionstatus.md) for the current status of each individual RFC (posting dates, comment periods, and DCC responses).
+
+### A note on RFC content
+
+The individual RFC documents are currently linked from [adoptionstatus.md](adoptionstatus.md) as Google Docs. For durable citation and archival, snapshots of accepted RFCs can be deposited directly in this repository, or archived to a persistent store such as [Zenodo](https://zenodo.org/), so that a stable, immutable copy is available independent of the original Google Docs.
+
+## License
+
+This repository is dedicated to the public domain under the Creative Commons CC0 1.0 Universal Public Domain Dedication, matching the nih-cfde organization convention. See [LICENSE.md](LICENSE.md) for the full text. You are free to copy, modify, and reuse the RFC materials without restriction.


### PR DESCRIPTION
This refreshes `README.md` to address peer-review concerns about licensing visibility, repository status, and the persistence of RFC content. It keeps the existing useful content (the pointer to `adoptionstatus.md` and the contribution/tagging instructions) and adds:

- **License** section noting the repository is dedicated to the public domain under CC0-1.0 (see `LICENSE.md`).
- **Status / maintenance** note clarifying that this repository tracks the historical CFDE RFC process and pointing readers to `adoptionstatus.md` for per-RFC status.
- **A note on RFC content** acknowledging that individual RFC documents are currently linked as Google Docs in `adoptionstatus.md`, and stating that for durable citation/archival, snapshots of accepted RFCs can be deposited in this repository or archived to a persistent store such as Zenodo.

No RFC content is migrated and no dates or DOIs are asserted; the persistence note describes an option for durable archival rather than claiming completed work.
